### PR TITLE
Stop on collision

### DIFF
--- a/controllers/tests/container_collision.py
+++ b/controllers/tests/container_collision.py
@@ -1,0 +1,36 @@
+from tdw.tdw_utils import TDWUtils
+from magnebot import ActionStatus
+from transport_challenge import Transport
+
+
+class ContainerCollision(Transport):
+    """
+    Test collisions between the Magnebot and a container.
+    """
+
+    def init_scene(self, scene: str = None, layout: int = None, room: int = None,
+                   goal_room: int = None, random_seed: int = 0) -> ActionStatus:
+        commands = [{"$type": "load_scene",
+                     "scene_name": "ProcGenScene"},
+                    TDWUtils.create_empty_room(12, 12)]
+        self._add_container(model_name="basket_18inx18inx12iin",
+                            position={"x": 0.235, "y": 0, "z": 1.5})
+        self._add_container(model_name="basket_18inx18inx12iin",
+                            position={"x": 0.235, "y": 1, "z": 1.25})
+        commands.extend(self._get_scene_init_commands())
+        resp = self.communicate(commands)
+        self._cache_static_data(resp=resp)
+        # Wait for the Magnebot to reset to its neutral position.
+        status = self._do_arm_motion()
+        self._end_action()
+        return status
+
+
+if __name__ == "__main__":
+    m = ContainerCollision(launch_build=False, random_seed=0, skip_frames=0)
+    m.init_scene()
+    print(m.move_by(8))
+    print(m.turn_by(70))
+    print(m.turn_by(-70))
+    print(m.move_by(-8))
+    m.end()

--- a/controllers/tests/fill_and_pour.py
+++ b/controllers/tests/fill_and_pour.py
@@ -10,7 +10,7 @@ class FillAndPour(Transport):
     """
 
     def init_scene(self, scene: str = None, layout: int = None, room: int = None,
-                   goal_room: int = None) -> ActionStatus:
+                   goal_room: int = None, random_seed: int = 0) -> ActionStatus:
         origin = np.array([0, 0, 0])
         commands = [{"$type": "load_scene",
                      "scene_name": "ProcGenScene"},

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
 ## 0.3.0
 
 - Requires: Magnebot 1.1.0 (see changelog notes regarding collision detection)
+  - Added optional parameter `stop_on_collision` to `move_by()`, `move_to()`, `turn_by()` and `turn_to()` Set this to False to ignore collision detection during the action
 - Fixed: Crash-to-desktop because a container gets caught in the Magnebot's wheels. Now, the Magnebot will stop moving as soon as a wheel collides with a container.
 - Added: `tests/container_collision.py`
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0
 
+- Requires: Magnebot 1.1.0 (see changelog notes regarding collision detection)
 - Fixed: Crash-to-desktop because a container gets caught in the Magnebot's wheels. Now, the Magnebot will stop moving as soon as a wheel collides with a container.
 - Added: `tests/container_collision.py`
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+- Fixed: Crash-to-desktop because a container gets caught in the Magnebot's wheels. Now, the Magnebot will stop moving as soon as a wheel collides with a container.
+- Added: `tests/container_collision.py`
+
 ## 0.2.3
 
 - Added optional parameter `check_pypi_version` to the constructor

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='transport_challenge',
-    version="0.2.3",
+    version="0.3.0",
     description='Transport Challenge API. Extends the Magnebot API and the TDW API.',
     long_description='Transport Challenge API. Extends the Magnebot API and the TDW API.',
     url='https://github.com/alters-mit/transport_challenge',

--- a/transport_challenge/transport_controller.py
+++ b/transport_challenge/transport_controller.py
@@ -7,6 +7,7 @@ from scipy.signal import convolve2d
 from tdw.py_impact import ObjectInfo, AudioMaterial
 from tdw.librarian import ModelLibrarian
 from tdw.tdw_utils import TDWUtils
+from tdw.int_pair import IntPair
 from magnebot import Magnebot, Arm, ActionStatus, ArmJoint
 from magnebot.scene_state import SceneState
 from magnebot.paths import ROOM_MAPS_DIRECTORY, OCCUPANCY_MAPS_DIRECTORY, SCENE_BOUNDS_PATH, SPAWN_POSITIONS_PATH
@@ -780,3 +781,8 @@ class Transport(Magnebot):
         commands.append({"$type": "set_field_of_view",
                          "field_of_view": self.__fov})
         return commands
+
+    def _is_stoppable_collision(self, id_pair: IntPair) -> bool:
+        # Stop for normal reasons or if the Magnebot collides with a container.
+        return super()._is_stoppable_collision(id_pair=id_pair) or (self._includes_magnebot_joint_and_object(
+            id_pair=id_pair) and id_pair.int1 in self.containers or id_pair.int2 in self.containers)


### PR DESCRIPTION
Closes #2 
Closes #3 
Closes #4 

- Requires: Magnebot 1.1.0 (see changelog notes regarding collision detection)
  - Added optional parameter `stop_on_collision` to `move_by()`, `move_to()`, `turn_by()` and `turn_to()` Set this to False to ignore collision detection during the action
- Fixed: Crash-to-desktop because a container gets caught in the Magnebot's wheels. Now, the Magnebot will stop moving as soon as a wheel collides with a container.
- Added: `tests/container_collision.py`