### PR TITLE
Failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ The Transport Challenge API is an extension of the [Magnebot API](https://github
 
 # Installation
 
-1. [Follow instructions for installing the Magnebot API](https://github.com/alters-mit/magnebot)
+1. [Download the latest TDW build and unzip it.](https://github.com/threedworld-mit/tdw/releases/latest)
 2. Clone this repo
 3. `cd path/to/transport_challenge` (Replace `path/to` with the actual path)
-4. `pip3 install -e .`
+4. `pip3 install -e .` This will install all underlying modules, including `magnebot` and `tdw`
+5. Make sure that the underlying TDW system is working correctly. See: [Getting Started With TDW](https://github.com/threedworld-mit/tdw/blob/master/Documentation/getting_started.md#Requirements)
+6. Make sure that you have the correct version of the `magnebot` module: `pip3 show magnebot`. The correct version is `1.1.1` If you have the wrong version: `pip3 install magnebot==1.1.1 --force-reinstall` 
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The Transport Challenge API is an extension of the [Magnebot API](https://github
 3. `cd path/to/transport_challenge` (Replace `path/to` with the actual path)
 4. `pip3 install -e .` This will install all underlying modules, including `magnebot` and `tdw`
 5. Make sure that the underlying TDW system is working correctly. See: [Getting Started With TDW](https://github.com/threedworld-mit/tdw/blob/master/Documentation/getting_started.md#Requirements)
-6. Make sure that you have the correct version of the `magnebot` module: `pip3 show magnebot`. The correct version is `1.1.1` If you have the wrong version: `pip3 install magnebot==1.1.1 --force-reinstall` 
 
 # Usage
 

--- a/controllers/promos/failure.py
+++ b/controllers/promos/failure.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     if target in m.state.held[Arm.right]:
         m.drop(target=target, arm=Arm.right, wait_for_objects=False)
     m.reset_arm(arm=Arm.right)
-    m.move_by(-0.2, arrived_at=0.05)
+    m.move_by(-0.2, arrived_at=0.05, stop_on_collision=False)
     m.pick_up(target=target, arm=Arm.right)
     m.move_by(-0.8, stop_on_collision=False)
     target = m.target_objects[1]

--- a/controllers/promos/failure.py
+++ b/controllers/promos/failure.py
@@ -1,0 +1,49 @@
+from magnebot import ActionStatus, Arm
+from transport_challenge.promo_controller import PromoController
+
+
+class Failure(PromoController):
+    """
+    Demo of a Magnebot trying an failing to do a task.
+    """
+
+    def init_scene(self, scene: str = "1a", layout: int = 1, room: int = 0, goal_room: int = None,
+                   random_seed: int = 0) -> ActionStatus:
+        super().init_scene(scene=scene, layout=layout, room=room, random_seed=random_seed)
+        # Move a target object under a chair.
+        self._next_frame_commands.append({"$type": "teleport_object",
+                                          "id": self.target_objects[0],
+                                          "position": {"x": -0.689, "y": 0, "z": 2.567}})
+        self._end_action()
+        return ActionStatus.success
+
+
+if __name__ == "__main__":
+    m = Failure(images_directory="D:/transport_challenge_failure_demo")
+    m.init_scene()
+    target = m.target_objects[0]
+    # Add an overhead camera. Note that `position` is relative to the Magnebot, not absolute worldspace coordinates.
+    m.add_camera(position={"x": -1.64, "y": 1.6, "z": -0.166}, look_at=True, follow=True)
+    # Collide with a chair.
+    m.move_to(target=target)
+    # Back away from the chair.
+    m.move_by(-0.5, stop_on_collision=False)
+    # Run into the chair again.
+    m.move_to(target=target)
+    # Run into it a little more.
+    m.move_by(0.3, stop_on_collision=False)
+    # Back up.
+    m.move_by(-0.6, stop_on_collision=False)
+    # Go around the chair.
+    m.turn_by(-35)
+    m.move_by(1.4, stop_on_collision=False)
+    m.turn_to(target=target, stop_on_collision=False)
+    # Collide with the table leg or chair.
+    m.move_by(0.8, stop_on_collision=False)
+    # Try to pick up the object. This sometimes succeeds, and sometimes doesn't (due to Unity physics).
+    status = m.pick_up(target=target, arm=Arm.right)
+    if status != ActionStatus.success:
+        m.pick_up(target=target, arm=Arm.left)
+    # Back away from the table.
+    m.move_by(-0.8, stop_on_collision=False)
+    m.end()

--- a/controllers/promos/failure.py
+++ b/controllers/promos/failure.py
@@ -47,11 +47,11 @@ if __name__ == "__main__":
     if target in m.state.held[Arm.right]:
         m.drop(target=target, arm=Arm.right, wait_for_objects=False)
     m.reset_arm(arm=Arm.right)
-    # Back away from the table.
+    m.move_by(-0.2, arrived_at=0.05)
+    m.pick_up(target=target, arm=Arm.right)
     m.move_by(-0.8, stop_on_collision=False)
-    # Pick up another object that is easier to get.
     target = m.target_objects[1]
-    m.move_to(target=target)
+    m.move_to(target=target, stop_on_collision=False)
     m.pick_up(target=target, arm=Arm.left)
-    m.move_by(-0.5)
+    m.move_by(0.5)
     m.end()

--- a/controllers/promos/failure.py
+++ b/controllers/promos/failure.py
@@ -10,16 +10,19 @@ class Failure(PromoController):
     def init_scene(self, scene: str = "1a", layout: int = 1, room: int = 0, goal_room: int = None,
                    random_seed: int = 0) -> ActionStatus:
         super().init_scene(scene=scene, layout=layout, room=room, random_seed=random_seed)
-        # Move a target object under a chair.
-        self._next_frame_commands.append({"$type": "teleport_object",
-                                          "id": self.target_objects[0],
-                                          "position": {"x": -0.689, "y": 0, "z": 2.567}})
+        # Move a target object under a chair and another target object nearby on the floor.
+        self._next_frame_commands.extend([{"$type": "teleport_object",
+                                           "id": self.target_objects[0],
+                                           "position": {"x": -0.689, "y": 0, "z": 2.567}},
+                                          {"$type": "teleport_object",
+                                           "id": self.target_objects[1],
+                                           "position": {"x": -1.34, "y": 0, "z": 1.894}}])
         self._end_action()
         return ActionStatus.success
 
 
 if __name__ == "__main__":
-    m = Failure(images_directory="D:/transport_challenge_failure_demo")
+    m = Failure(images_directory="D:/transport_challenge_failure_demo", screen_height=1024, screen_width=1024)
     m.init_scene()
     target = m.target_objects[0]
     # Add an overhead camera. Note that `position` is relative to the Magnebot, not absolute worldspace coordinates.
@@ -32,18 +35,23 @@ if __name__ == "__main__":
     m.move_to(target=target)
     # Run into it a little more.
     m.move_by(0.3, stop_on_collision=False)
-    # Back up.
-    m.move_by(-0.6, stop_on_collision=False)
     # Go around the chair.
-    m.turn_by(-35)
-    m.move_by(1.4, stop_on_collision=False)
+    m.move_by(-0.8, stop_on_collision=False)
+    m.move_to(target={"x": -0.448, "y": 0, "z": 1.605}, stop_on_collision=False)
     m.turn_to(target=target, stop_on_collision=False)
     # Collide with the table leg or chair.
     m.move_by(0.8, stop_on_collision=False)
     # Try to pick up the object. This sometimes succeeds, and sometimes doesn't (due to Unity physics).
-    m.pick_up(target=target, arm=Arm.right)
-    if target not in m.state.held[Arm.right]:
-        m.pick_up(target=target, arm=Arm.left)
+    m.grasp(target=target, arm=Arm.right)
+    # Immediately drop the object to simulate a failure.
+    if target in m.state.held[Arm.right]:
+        m.drop(target=target, arm=Arm.right, wait_for_objects=False)
+    m.reset_arm(arm=Arm.right)
     # Back away from the table.
     m.move_by(-0.8, stop_on_collision=False)
+    # Pick up another object that is easier to get.
+    target = m.target_objects[1]
+    m.move_to(target=target)
+    m.pick_up(target=target, arm=Arm.left)
+    m.move_by(-0.5)
     m.end()

--- a/controllers/promos/failure.py
+++ b/controllers/promos/failure.py
@@ -41,8 +41,8 @@ if __name__ == "__main__":
     # Collide with the table leg or chair.
     m.move_by(0.8, stop_on_collision=False)
     # Try to pick up the object. This sometimes succeeds, and sometimes doesn't (due to Unity physics).
-    status = m.pick_up(target=target, arm=Arm.right)
-    if status != ActionStatus.success:
+    m.pick_up(target=target, arm=Arm.right)
+    if target not in m.state.held[Arm.right]:
         m.pick_up(target=target, arm=Arm.left)
     # Back away from the table.
     m.move_by(-0.8, stop_on_collision=False)

--- a/controllers/promos/promo.py
+++ b/controllers/promos/promo.py
@@ -1,16 +1,15 @@
 from os import chdir
-from typing import Dict, List, Union
+from typing import List
 from pathlib import Path
 from subprocess import call
 from json import loads
 import numpy as np
 from tdw.tdw_utils import TDWUtils
-from tdw.output_data import OutputData, Images
 from magnebot import ActionStatus, Arm
-from transport_challenge import Transport
+from transport_challenge.promo_controller import PromoController
 
 
-class Demo(Transport):
+class Demo(PromoController):
     """
     A demo of a Magnebot using a container to transport target objects to a new room.
 
@@ -34,17 +33,9 @@ class Demo(Transport):
 
     def __init__(self, port: int = 1071, screen_width: int = 1024, screen_height: int = 1024,
                  images_directory: str = "images", image_pass_only: bool = False, overhead_camera_only: bool = False):
-        super().__init__(port=port, launch_build=False, screen_width=screen_width, screen_height=screen_height,
-                         auto_save_images=False, debug=False, images_directory=images_directory, random_seed=16,
-                         img_is_png=False, skip_frames=0)
-
-        self.image_directories: Dict[str, Path] = dict()
-        self.image_pass_only = image_pass_only
-        self.overhead_camera_only = overhead_camera_only
-        if not overhead_camera_only:
-            self._create_images_directory(avatar_id="a")
-
-        self._image_count = 0
+        super().__init__(port=port, screen_width=screen_width, screen_height=screen_height,
+                         images_directory=images_directory, random_seed=16, image_pass_only=image_pass_only,
+                         overhead_camera_only=overhead_camera_only)
         self._to_transport: List[int] = list()
 
     def init_scene(self, scene: str, layout: int, room: int = None, goal_room: int = None,
@@ -53,55 +44,6 @@ class Demo(Transport):
 
         self._to_transport = self.target_objects[:]
         return status
-
-    def add_camera(self, position: Dict[str, float], roll: float = 0, pitch: float = 0, yaw: float = 0,
-                   look_at: bool = True, follow: bool = False, camera_id: str = "c") -> ActionStatus:
-        """
-        See: `Magnebot.add_camera()`.
-
-        Adds some instructions to render images per-frame.
-        """
-
-        self._create_images_directory(avatar_id=camera_id)
-        status = super().add_camera(position=position, roll=roll, pitch=pitch, yaw=yaw, look_at=look_at, follow=follow,
-                                    camera_id=camera_id)
-        # Always save images.
-        if not self._debug:
-            if self.overhead_camera_only:
-                self._per_frame_commands.extend([{"$type": "enable_image_sensor",
-                                                  "enable": True},
-                                                 {"$type": "send_images",
-                                                  "ids": ["c"]}])
-            else:
-                self._per_frame_commands.extend([{"$type": "enable_image_sensor",
-                                                  "enable": True},
-                                                 {"$type": "send_images"}])
-        return status
-
-    def communicate(self, commands: Union[dict, List[dict]]) -> List[bytes]:
-        """
-        See `Magnebot.communicate()`.
-
-        Images are saved per-frame.
-        """
-
-        resp = super().communicate(commands=commands)
-        if not self._debug:
-            # Save all images.
-            got_images = False
-            for i in range(len(resp) - 1):
-                r_id = OutputData.get_data_type_id(resp[i])
-                if r_id == "imag":
-                    got_images = True
-                    images = Images(resp[i])
-                    avatar_id = images.get_avatar_id()
-                    if avatar_id in self.image_directories:
-                        TDWUtils.save_images(filename=TDWUtils.zero_padding(self._image_count, 8),
-                                             output_directory=self.image_directories[avatar_id],
-                                             images=images)
-            if got_images:
-                self._image_count += 1
-        return resp
 
     def transport(self) -> None:
         """
@@ -154,29 +96,6 @@ class Demo(Transport):
                                                    "id": object_id,
                                                    "rotation": object_data["rotation"]}])
         self._end_action()
-
-    def _get_scene_init_commands(self, magnebot_position: Dict[str, float] = None) -> List[dict]:
-        commands = super()._get_scene_init_commands(magnebot_position=magnebot_position)
-        # Hide the roof.
-        commands.append({"$type": "set_floorplan_roof",
-                         "show": False})
-        if self.image_pass_only:
-            commands.append({"$type": "set_pass_masks",
-                             "pass_masks": ["_img"]})
-        return commands
-
-    def _create_images_directory(self, avatar_id: str) -> None:
-        """
-        :param avatar_id: The ID of the avatar.
-
-        :return: An images directory for the avatar.
-        """
-
-        # Build the images directory.
-        a_dir = self.images_directory.joinpath(avatar_id)
-        if not a_dir.exists():
-            a_dir.mkdir(parents=True)
-        self.image_directories[avatar_id] = a_dir
 
 
 if __name__ == "__main__":

--- a/controllers/promos/success.py
+++ b/controllers/promos/success.py
@@ -1,0 +1,33 @@
+from transport_challenge import Transport
+from magnebot import Arm
+from tdw.tdw_utils import TDWUtils
+
+"""
+An example of the Magnebot successfully completing a transport task.
+"""
+
+if __name__ == '__main__':
+    m = Transport(launch_build=False, screen_width=1024, screen_height=1024, fov=90)
+    m.init_scene(scene="5a", layout=2, random_seed=9420)
+    m.add_camera(position={"x": -2, "y": 0.75, "z": 0}, look_at=True, follow=True)
+    # This is the closest container.
+    m.move_to(target=m.containers[0])
+    m.pick_up(target=m.containers[0], arm=Arm.right)
+    # Go to the other room.
+    for waypoint in [[-4.91, 0, -0.73], [-4.91, 0, 1.09]]:
+        m.move_to(target=TDWUtils.array_to_vector3(waypoint))
+    # Pick up some objects.
+    for target_object_index in [1, 5, 0]:
+        m.move_to(target=m.target_objects[target_object_index], stop_on_collision=False)
+        m.pick_up(target=m.target_objects[target_object_index], arm=Arm.left)
+        m.put_in()
+    # Go to the other room.
+    for waypoint in [[-0.49, 0, 4.49], [1.23, 0, 4.49]]:
+        m.move_to(target=TDWUtils.array_to_vector3(waypoint))
+    # Move to the table.
+    for waypoint in [[3.44, 0, 3.09], [4.49, 0, 2.58]]:
+        m.move_to(target=TDWUtils.array_to_vector3(waypoint))
+    m.pour_out()
+    m.reset_arm(arm=Arm.right)
+    m.move_by(-1)
+    m.end()

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.2
+
+- Added: `promo_controller.y` Base class for promo controllers
+- Added: `failure.py` Demo of the Magnebot failing a task
+
 ## 0.3.1
 
 - Fixed: Object URLs are not set correctly if the `TRANSPORT_CHALLENGE` environment variable is provided

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,8 +2,12 @@
 
 ## 0.3.2
 
+- **The Transport Challenge API requires Magnebot v1.1.2 and should NOT be upgraded past this version!**
+  - pip will install the correct version of Magnebot
+  - Added: `Transport.MAGNEBOT_VERSION` The required version of the Magnebot Python module
 - Added: `promo_controller.y` Base class for promo controllers
 - Added: `failure.py` Demo of the Magnebot failing a task
+- Added: `success.py` Demo of the Magnebot succeeding at a task
 
 ## 0.3.1
 

--- a/doc/transport_controller.md
+++ b/doc/transport_controller.md
@@ -59,6 +59,7 @@ This API includes the following changes and additions:
 | `TARGET_OBJECT_MASS` | float | The mass of each target object. |
 | `GOAL_ZONE_RADIUS` | float | The goal zone is a circle defined by `self.goal_center` and this radius value. |
 | `NUM_TARGET_OBJECTS` | int | The total number of target objects in a scene. |
+| `MAGNEBOT_VERSION` | str | The required version of the Magnebot Python module. Don't upgrade past this version! |
 
 ***
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='transport_challenge',
-    version="0.3.1",
+    version="0.3.2",
     description='Transport Challenge API. Extends the Magnebot API and the TDW API.',
     long_description='Transport Challenge API. Extends the Magnebot API and the TDW API.',
     url='https://github.com/alters-mit/transport_challenge',

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     ],
     keywords='unity simulation tdw magnebot',
     packages=find_packages(),
-    install_requires=['magnebot', 'numpy', 'tdw', 'scipy']
+    install_requires=['magnebot==1.1.1', 'numpy', 'tdw', 'scipy']
 )

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     ],
     keywords='unity simulation tdw magnebot',
     packages=find_packages(),
-    install_requires=['magnebot==1.1.1', 'numpy', 'tdw', 'scipy']
+    install_requires=['magnebot==1.1.2', 'numpy', 'tdw', 'scipy']
 )

--- a/transport_challenge/promo_controller.py
+++ b/transport_challenge/promo_controller.py
@@ -1,0 +1,101 @@
+from typing import Dict, List, Union
+from pathlib import Path
+from tdw.tdw_utils import TDWUtils
+from tdw.output_data import OutputData, Images
+from magnebot import ActionStatus
+from transport_challenge import Transport
+
+
+class PromoController(Transport):
+    """
+    This class is meant to be used for generating promo videos.
+    It will automatically save every image per physics simulation step (NOT per-action) from 1-2 cameras (Magnebot and/or overhead).
+    This means that this controller will run very slowly.
+    """
+
+    def __init__(self, port: int = 1071, screen_width: int = 1024, screen_height: int = 1024,
+                 images_directory: str = "images", image_pass_only: bool = False, overhead_camera_only: bool = False,
+                 random_seed: int = None):
+        super().__init__(port=port, launch_build=False, screen_width=screen_width, screen_height=screen_height,
+                         auto_save_images=False, debug=False, images_directory=images_directory, random_seed=random_seed,
+                         img_is_png=False, skip_frames=0)
+
+        self.image_directories: Dict[str, Path] = dict()
+        self.image_pass_only = image_pass_only
+        self.overhead_camera_only = overhead_camera_only
+        if not overhead_camera_only:
+            self._create_images_directory(avatar_id="a")
+
+        self._image_count = 0
+
+    def add_camera(self, position: Dict[str, float], roll: float = 0, pitch: float = 0, yaw: float = 0,
+                   look_at: bool = True, follow: bool = False, camera_id: str = "c") -> ActionStatus:
+        """
+        See: `Magnebot.add_camera()`.
+
+        Adds some instructions to render images per-frame.
+        """
+
+        self._create_images_directory(avatar_id=camera_id)
+        status = super().add_camera(position=position, roll=roll, pitch=pitch, yaw=yaw, look_at=look_at, follow=follow,
+                                    camera_id=camera_id)
+        # Always save images.
+        if not self._debug:
+            if self.overhead_camera_only:
+                self._per_frame_commands.extend([{"$type": "enable_image_sensor",
+                                                  "enable": True},
+                                                 {"$type": "send_images",
+                                                  "ids": ["c"]}])
+            else:
+                self._per_frame_commands.extend([{"$type": "enable_image_sensor",
+                                                  "enable": True},
+                                                 {"$type": "send_images"}])
+        return status
+
+    def communicate(self, commands: Union[dict, List[dict]]) -> List[bytes]:
+        """
+        See `Magnebot.communicate()`.
+
+        Images are saved per-frame.
+        """
+
+        resp = super().communicate(commands=commands)
+        if not self._debug:
+            # Save all images.
+            got_images = False
+            for i in range(len(resp) - 1):
+                r_id = OutputData.get_data_type_id(resp[i])
+                if r_id == "imag":
+                    got_images = True
+                    images = Images(resp[i])
+                    avatar_id = images.get_avatar_id()
+                    if avatar_id in self.image_directories:
+                        TDWUtils.save_images(filename=TDWUtils.zero_padding(self._image_count, 8),
+                                             output_directory=self.image_directories[avatar_id],
+                                             images=images)
+            if got_images:
+                self._image_count += 1
+        return resp
+
+    def _create_images_directory(self, avatar_id: str) -> None:
+        """
+        :param avatar_id: The ID of the avatar.
+
+        :return: An images directory for the avatar.
+        """
+
+        # Build the images directory.
+        a_dir = self.images_directory.joinpath(avatar_id)
+        if not a_dir.exists():
+            a_dir.mkdir(parents=True)
+        self.image_directories[avatar_id] = a_dir
+
+    def _get_scene_init_commands(self, magnebot_position: Dict[str, float] = None) -> List[dict]:
+        commands = super()._get_scene_init_commands(magnebot_position=magnebot_position)
+        # Hide the roof.
+        commands.append({"$type": "set_floorplan_roof",
+                         "show": False})
+        if self.image_pass_only:
+            commands.append({"$type": "set_pass_masks",
+                             "pass_masks": ["_img"]})
+        return commands

--- a/transport_challenge/transport_controller.py
+++ b/transport_challenge/transport_controller.py
@@ -102,8 +102,7 @@ class Transport(Magnebot):
 
     def __init__(self, port: int = 1071, launch_build: bool = False, screen_width: int = 256, screen_height: int = 256,
                  debug: bool = False, auto_save_images: bool = False, images_directory: str = "images",
-                 random_seed: int = None, img_is_png: bool = False, skip_frames: int = 10, fov: float = 90,
-                 check_pypi_version: bool = True):
+                 random_seed: int = None, img_is_png: bool = False, skip_frames: int = 10, fov: float = 90):
         """
         :param port: The socket port. [Read this](https://github.com/threedworld-mit/tdw/blob/master/Documentation/getting_started.md#command-line-arguments) for more information.
         :param launch_build: If True, the build will launch automatically on the default port (1071). If False, you will need to launch the build yourself (for example, from a Docker container).
@@ -116,13 +115,12 @@ class Transport(Magnebot):
         :param img_is_png: If True, the `img` pass images will be .png files. If False, the `img` pass images will be .jpg files, which are smaller; the build will run approximately 2% faster.
         :param skip_frames: The build will return output data this many frames per `communicate()` call. This will greatly speed up the simulation. If you want to render every frame, set this to 0.
         :param fov: The field of view for the Magnebot's camera.
-        :param check_pypi_version: If True, compare the locally installed version of TDW and Magnebot to the most recent versions on PyPi.
         """
 
         super().__init__(port=port, launch_build=launch_build, screen_width=screen_width, screen_height=screen_height,
                          debug=debug, auto_save_images=auto_save_images, images_directory=images_directory,
                          random_seed=random_seed, img_is_png=img_is_png, skip_frames=skip_frames,
-                         check_pypi_version=check_pypi_version)
+                         check_pypi_version=False)
         """:field
         The IDs of each target object in the scene.
         """

--- a/transport_challenge/transport_controller.py
+++ b/transport_challenge/transport_controller.py
@@ -1,4 +1,5 @@
 from os import environ
+from pkg_resources import get_distribution
 from json import loads
 from csv import DictReader
 from typing import List, Dict, Tuple, Optional, Union
@@ -99,6 +100,10 @@ class Transport(Magnebot):
     The total number of target objects in a scene.
     """
     NUM_TARGET_OBJECTS: int = 8
+    """:class_var
+    The required version of the Magnebot Python module. Don't upgrade past this version!
+    """
+    MAGNEBOT_VERSION: str = "1.1.2"
 
     def __init__(self, port: int = 1071, launch_build: bool = False, screen_width: int = 256, screen_height: int = 256,
                  debug: bool = False, auto_save_images: bool = False, images_directory: str = "images",
@@ -116,6 +121,11 @@ class Transport(Magnebot):
         :param skip_frames: The build will return output data this many frames per `communicate()` call. This will greatly speed up the simulation. If you want to render every frame, set this to 0.
         :param fov: The field of view for the Magnebot's camera.
         """
+
+        magnebot_version = str(get_distribution("magnebot")).split(" ")[1]
+        assert magnebot_version == Transport.MAGNEBOT_VERSION, f"You have the wrong version of the Magnebot Python module. " \
+                                                               f"To re-install:\n1. pip3 uninstall magnebot\n" \
+                                                               f"2. pip3 install magnebot=={Transport.MAGNEBOT_VERSION}"
 
         super().__init__(port=port, launch_build=launch_build, screen_width=screen_width, screen_height=screen_height,
                          debug=debug, auto_save_images=auto_save_images, images_directory=images_directory,


### PR DESCRIPTION
- **The Transport Challenge API requires Magnebot v1.1.2 and should NOT be upgraded past this version!**
  - For new users, pip will install the correct version of Magnebot
  - Added: `Transport.MAGNEBOT_VERSION` The required version of the Magnebot Python module
- Added: `promo_controller.y` Base class for promo controllers
- Added: `failure.py` Demo of the Magnebot failing a task
- Added: `success.py` Demo of the Magnebot succeeding at a task

